### PR TITLE
Fix array handling logic and formatter quote, rename misleading function

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/attacktive/js-loose-equals/badge)](https://www.codefactor.io/repository/github/attacktive/js-loose-equals)
 [![pages-build-deployment](https://github.com/Attacktive/javascript-loosely-equal-example-giver/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Attacktive/javascript-loosely-equal-example-giver/actions/workflows/pages/pages-build-deployment)
 
-Incomplete and buggy
+Enter any JavaScript expression to see what other values are loosely equal to it via `==`. Probably still incomplete.

--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -190,29 +190,21 @@ function handleSpecialCases(x) {
  * @return {Example}
  */
 function handleArray(array) {
-	if (isNestedEmptyArray(array) || isNumberInNestedArray(0, array)) {
-		return {
-			isInfinite: false,
-			examples: [false, 0, '']
-		};
-	}
-	if (isNumberInNestedArray(0, array)) {
-		return {
-			isInfinite: false,
-			examples: [false, 0, '0']
-		};
-	}
-	if (isNumberInNestedArray(1, array)) {
-		return {
-			isInfinite: false,
-			examples: [true, 1, '1']
-		};
+	const isInfinite = false;
+
+	if (isNestedEmptyArray(array)) {
+		return { isInfinite, examples: [false, 0, ''] };
 	}
 
-	return {
-		isInfinite: false,
-		examples: []
-	};
+	if (isNumberInNestedArray(0, array)) {
+		return { isInfinite, examples: [false, 0, '0'] };
+	}
+
+	if (isNumberInNestedArray(1, array)) {
+		return { isInfinite, examples: [true, 1, '1'] };
+	}
+
+	return { isInfinite, examples: [] };
 }
 
 /**

--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -196,11 +196,11 @@ function handleArray(array) {
 		return { isInfinite, examples: [false, 0, ''] };
 	}
 
-	if (isNumberInNestedArray(0, array)) {
+	if (isNestedSingletonOf(0, array)) {
 		return { isInfinite, examples: [false, 0, '0'] };
 	}
 
-	if (isNumberInNestedArray(1, array)) {
+	if (isNestedSingletonOf(1, array)) {
 		return { isInfinite, examples: [true, 1, '1'] };
 	}
 
@@ -301,14 +301,14 @@ function isNestedEmptyArray(array) {
  * @param {Array} array
  * @return {boolean}
  */
-function isNumberInNestedArray(target, array) {
+function isNestedSingletonOf(target, array) {
 	if (array.length !== 1) {
 		return false;
 	}
 
 	const theOnlyElement = array[0];
 	if (Array.isArray(theOnlyElement)) {
-		return isNumberInNestedArray(target, theOnlyElement);
+		return isNestedSingletonOf(target, theOnlyElement);
 	} else {
 		let parsed = parseFloat(theOnlyElement);
 		return (parsed === target);

--- a/scripts/formatter.js
+++ b/scripts/formatter.js
@@ -30,7 +30,7 @@ function format(input, n) {
 			}
 
 			if (input instanceof String) {
-				return formatNonPrimitive(input, n, () => `new ${input.constructor.name}("${input})"`);
+				return formatNonPrimitive(input, n, () => `new ${input.constructor.name}("${input}")`);
 			}
 
 			if (input instanceof Date) {


### PR DESCRIPTION
## Summary

- **`handleArray` bug**: the original condition `isNestedEmptyArray(array) || isNumberInNestedArray(0, array)` meant `[0]` would return `''` as a loose-equal example — but `[0] == ''` is actually `false`. Split into two separate `if`s so `[0]` correctly returns `'0'`.
- **`formatter.js` typo**: `\`new ${input.constructor.name}("${input})"\`` had the closing `"` inside the `)`, producing `new String("hello)"` instead of `new String("hello")`.
- **Rename**: `isNumberInNestedArray` → `isNestedSingletonOf` — the old name implied a search, but the function checks structure (every nesting level must have exactly one element).
- **README**: replaced "Incomplete and buggy" with an actual description.

## Test plan

- [ ] Input `[0]` — should show `false`, `0`, `'0'` (not `''`)
- [ ] Input `[]` — should still show `false`, `0`, `''`
- [ ] Input `[[1]]` — should show `true`, `1`, `'1'`
- [ ] Verify `new String(...)` formatting renders correctly for boxed String values

🤖 Generated with [Claude Code](https://claude.com/claude-code)