### PR TITLE
fix: remove stray semicolon appended by formatNonPrimitive

### DIFF
--- a/scripts/formatter.js
+++ b/scripts/formatter.js
@@ -66,7 +66,5 @@ function formatNonPrimitive(any, n, representation) {
 		formatted += ")";
 	}
 
-	formatted += ";";
-
 	return formatted;
 }

--- a/tests/formatter.test.js
+++ b/tests/formatter.test.js
@@ -1,0 +1,20 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// formatter.js is a plain browser script without exports; direct eval brings its declarations into scope
+eval(fs.readFileSync(path.join(__dirname, '../scripts/formatter.js'), 'utf-8'));
+
+test(
+	'format does not append a semicolon to non-primitives',
+	() => assert.equal(format(new Date(), 1), 'Object(new Date())')
+);
+
+test(
+	'format leaves primitives untouched by semicolons',
+	() => {
+		assert.equal(format('abc'), '"abc"');
+		assert.equal(format(42), '42');
+	}
+);


### PR DESCRIPTION
## Summary
- `formatNonPrimitive` appended a trailing `";"`, but callers add their own punctuation — producing `const x = new Date();;` and mid-expression semicolons like `x == Object(new Date());`
- Dropped the stray append; semicolons are now the caller's job
- Added a minimal `node:test`-based test suite (`tests/formatter.test.js`, zero dependencies) that reproduces the bug and guards against regression

Closes #33

## Test Plan
- [x] `node --test tests/formatter.test.js` — both tests pass (watched the new test fail before the fix, TDD-style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)