### PR TITLE
ci: update CodeQL actions and fix Dependabot directory

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: 'github-actions'
-    directory: '/.github'
+    directory: '/'
     schedule:
       interval: 'daily'
       time: '00:00'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: 'Checkout repository'
-      uses: 'actions/checkout@v3'
+      uses: 'actions/checkout@v6'
 
     # Initializes the CodeQL tools for scanning.
     - name: 'Initialize CodeQL'
-      uses: 'github/codeql-action/init@v2'
+      uses: 'github/codeql-action/init@v4'
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,21 +53,5 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: 'Autobuild'
-      uses: 'github/codeql-action/autobuild@v2'
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
     - name: 'Perform CodeQL Analysis'
-      uses: 'github/codeql-action/analyze@v2'
+      uses: 'github/codeql-action/analyze@v4'


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` to v6 and `github/codeql-action` (init/analyze) to v4 — v2 of the CodeQL Action was deprecated in early 2025, so the scheduled daily scans were failing. Also drops the `Autobuild` step, which is a no-op for plain JavaScript.
- Fix `.github/dependabot.yaml`: the `github-actions` ecosystem requires `directory: '/'` (Dependabot then scans `.github/workflows` itself). With `'/.github'` it found no workflow files, which is why no update PRs ever appeared and the manual "Check for updates" button was missing under Insights → Dependency graph → Dependabot.

Closes #34

## Test plan
- [ ] CodeQL workflow runs green on this PR (it triggers on `pull_request` to `main`)
- [ ] After merge, Insights → Dependency graph → Dependabot lists the `github-actions` manifest with a "Check for updates" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)