### PR TITLE
fix: predict string-to-number equality with ToNumber semantics

### DIFF
--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -34,7 +34,7 @@ function giveExamples(x) {
 			throw Error(`${x} is another Boolean value other than true or false!?`);
 		case 'string': {
 			const parsed = tryParsingToNumber(x);
-			if (parsed) {
+			if (parsed !== undefined) {
 				return {
 					isInfinite: true,
 					examples: [x, parsed].concat(generateWrappedArrayUpToNTimes(x, 10, String))
@@ -264,17 +264,12 @@ function handleFunction(fn) {
  * @return {undefined|number}
  */
 function tryParsingToNumber(string) {
-	let parsed = parseInt(string, 10);
-	if (Number.isInteger(parsed)) {
-		return parsed;
+	const parsed = Number(string);
+	if (Number.isNaN(parsed)) {
+		return undefined;
 	}
 
-	parsed = parseFloat(string);
-	if (Number.isFinite(parsed)) {
-		return parsed;
-	}
-
-	return undefined;
+	return parsed;
 }
 
 /**
@@ -310,7 +305,7 @@ function isNestedSingletonOf(target, array) {
 	if (Array.isArray(theOnlyElement)) {
 		return isNestedSingletonOf(target, theOnlyElement);
 	} else {
-		let parsed = parseFloat(theOnlyElement);
+		const parsed = Number(theOnlyElement);
 		return (parsed === target);
 	}
 }

--- a/tests/example-giver.test.js
+++ b/tests/example-giver.test.js
@@ -1,0 +1,54 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// example-giver.js is a plain browser script without exports; direct eval brings its declarations into scope
+eval(fs.readFileSync(path.join(__dirname, '../scripts/example-giver.js'), 'utf-8'));
+
+test(
+	'"1.5" is equated with 1.5, not the parseInt result 1',
+	() => {
+		const { examples } = giveExamples('1.5');
+
+		assert.ok(examples.includes(1.5));
+		assert.ok(!examples.includes(1));
+	}
+);
+
+test(
+	'"1e3" is equated with 1000, not the parseInt result 1',
+	() => {
+		const { examples } = giveExamples('1e3');
+
+		assert.ok(examples.includes(1000));
+		assert.ok(!examples.includes(1));
+	}
+);
+
+test(
+	'"1abc" is not equated with any number despite parseFloat accepting it',
+	() => {
+		const { examples } = giveExamples('1abc');
+
+		assert.ok(examples.every((example) => typeof example !== 'number'));
+	}
+);
+
+test(
+	'"00" is equated with 0 even though 0 is falsy',
+	() => {
+		const { examples } = giveExamples('00');
+
+		assert.ok(examples.includes(0));
+	}
+);
+
+test(
+	'["1abc"] is not claimed to equal 1',
+	() => {
+		const { examples } = giveExamples(['1abc']);
+
+		assert.deepEqual(examples, []);
+	}
+);


### PR DESCRIPTION
## Summary
`==` coerces strings with `Number()` (ToNumber) semantics, but the app predicted equalities with `parseInt`/`parseFloat`, which are far more lenient. That produced false claims like `"1.5" == 1`, `"1e3" == 1`, `"1abc" == 1` and `["1abc"] == 1`.

- `tryParsingToNumber` now uses `Number(string)` with a `Number.isNaN` check — exactly the coercion `==` performs — instead of trying `parseInt` then `parseFloat`.
- `isNestedSingletonOf` likewise uses `Number()` instead of `parseFloat`, so `["1abc"]` is no longer claimed to equal `1`.
- `giveExamples` checks `parsed !== undefined` instead of truthiness, so a successfully parsed `0` (e.g. from `"00"`) is no longer treated as a parse failure — `"00" == 0` is now listed.
- Bonus: `"Infinity" == Infinity` (which is true) is no longer excluded by the old `Number.isFinite` check.

Closes #27

## Test plan
- [x] Added `tests/example-giver.test.js` (TDD: all five tests watched failing against the old implementation first) covering `"1.5"`, `"1e3"`, `"1abc"`, `"00"` and `["1abc"]`
- [x] `node --test 'tests/**/*.test.js'` — 7 pass, 0 fail (including the existing formatter tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)