### PR TITLE
documentation: fix stale README badge URL and imprecise JSDoc return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.idea
+.idea/
 *.iws

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JavaScript Loosely Equal Example Giver
 
 [![CodeFactor](https://www.codefactor.io/repository/github/attacktive/js-loose-equals/badge)](https://www.codefactor.io/repository/github/attacktive/js-loose-equals)
-[![pages-build-deployment](https://github.com/Attacktive/javascript-loosely-equal-example-giver/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Attacktive/javascript-loosely-equal-example-giver/actions/workflows/pages/pages-build-deployment)
+[![pages-build-deployment](https://github.com/Attacktive/js-loose-equals/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Attacktive/js-loose-equals/actions/workflows/pages/pages-build-deployment)
 
 Enter any JavaScript expression to see what other values are loosely equal to it via `==`. Probably still incomplete.

--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -67,7 +67,7 @@ function giveExamples(x) {
 
 /**
  * @param x
- * @return {Example}
+ * @return {Example|undefined}
  */
 function handleSpecialCases(x) {
 	if (Number.isNaN(x)) {


### PR DESCRIPTION
The pages-build-deployment badge in the README still pointed at the repository's old name (`javascript-loosely-equal-example-giver`); it now points at `js-loose-equals`. Also normalizes the `.gitignore` entry to `.idea/` and corrects the JSDoc on `handleSpecialCases` to `@return {Example|undefined}`, since it intentionally returns nothing for non-special values.

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)