### PR TITLE
bugfix: derive array equalities from actual string coercion

### DIFF
--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -186,25 +186,31 @@ function handleSpecialCases(x) {
 }
 
 /**
+ * Under `==` an array coerces via ToPrimitive to `String(array)`, so it is loosely equal to that string, to the number the string parses to (if any), and to the boolean whose numeric value matches.
  * @param {Array} array
  * @return {Example}
  */
 function handleArray(array) {
-	const isInfinite = false;
+	const string = String(array);
+	const parsed = tryParsingToNumber(string);
+	const examples = [];
 
-	if (isNestedEmptyArray(array)) {
-		return { isInfinite, examples: [false, 0, ''] };
+	if (parsed === 0) {
+		examples.push(false);
+	} else if (parsed === 1) {
+		examples.push(true);
 	}
 
-	if (isNestedSingletonOf(0, array)) {
-		return { isInfinite, examples: [false, 0, '0'] };
+	if (parsed !== undefined) {
+		examples.push(parsed);
 	}
 
-	if (isNestedSingletonOf(1, array)) {
-		return { isInfinite, examples: [true, 1, '1'] };
-	}
+	examples.push(string);
 
-	return { isInfinite, examples: [] };
+	return {
+		isInfinite: false,
+		examples
+	};
 }
 
 /**
@@ -270,44 +276,6 @@ function tryParsingToNumber(string) {
 	}
 
 	return parsed;
-}
-
-/**
- * @param {Array} array
- * @return {boolean}
- */
-function isNestedEmptyArray(array) {
-	if (!Array.isArray(array)) {
-		return false;
-	}
-	if (array.length === 0) {
-		return true;
-	}
-	if (array.length > 1) {
-		return false;
-	}
-
-	const theOnlyElement = array[0];
-	return isNestedEmptyArray(theOnlyElement);
-}
-
-/**
- * @param {number} target
- * @param {Array} array
- * @return {boolean}
- */
-function isNestedSingletonOf(target, array) {
-	if (array.length !== 1) {
-		return false;
-	}
-
-	const theOnlyElement = array[0];
-	if (Array.isArray(theOnlyElement)) {
-		return isNestedSingletonOf(target, theOnlyElement);
-	} else {
-		const parsed = Number(theOnlyElement);
-		return (parsed === target);
-	}
 }
 
 /**

--- a/tests/example-giver.test.js
+++ b/tests/example-giver.test.js
@@ -49,6 +49,78 @@ test(
 	() => {
 		const { examples } = giveExamples(['1abc']);
 
-		assert.deepEqual(examples, []);
+		assert.ok(examples.every((example) => typeof example !== 'number'));
+	}
+);
+
+test(
+	'["1abc"] is equated with its string form',
+	() => {
+		const { examples } = giveExamples(['1abc']);
+
+		assert.ok(examples.includes('1abc'));
+	}
+);
+
+test(
+	'[2] is equated with 2 and "2"',
+	() => {
+		const { examples } = giveExamples([2]);
+
+		assert.ok(examples.includes(2));
+		assert.ok(examples.includes('2'));
+	}
+);
+
+test(
+	'[1,2] is equated with "1,2"',
+	() => {
+		const { examples } = giveExamples([1, 2]);
+
+		assert.ok(examples.includes('1,2'));
+	}
+);
+
+test(
+	'[" "] is equated with 0 but not with "0"',
+	() => {
+		const { examples } = giveExamples([' ']);
+
+		assert.ok(examples.includes(0));
+		assert.ok(!examples.includes('0'));
+	}
+);
+
+test(
+	'[null] is equated with "" but not with "0"',
+	() => {
+		const { examples } = giveExamples([null]);
+
+		assert.ok(examples.includes(''));
+		assert.ok(!examples.includes('0'));
+	}
+);
+
+test(
+	'nested falsy/truthy singleton arrays keep their equalities',
+	() => {
+		assert.deepEqual(giveExamples([]).examples, [false, 0, '']);
+		assert.deepEqual(giveExamples([0]).examples, [false, 0, '0']);
+		assert.deepEqual(giveExamples([1]).examples, [true, 1, '1']);
+		assert.deepEqual(giveExamples([['0']]).examples, [false, 0, '0']);
+	}
+);
+
+test(
+	'every array example is actually loosely equal to the array',
+	() => {
+		const arrays = [[], [0], [1], [2], [1, 2], ['1abc'], [' '], [null], [[42]]];
+
+		for (const array of arrays) {
+			const { examples } = giveExamples(array);
+
+			assert.ok(examples.length > 0);
+			assert.ok(examples.every((example) => example == array));
+		}
 	}
 );


### PR DESCRIPTION
`handleArray` used hand-rolled nested-singleton checks (`isNestedEmptyArray`/`isNestedSingletonOf`) that guessed at what `==` does, producing false claims like `[' '] == '0'` and `[null] == '0'` — both actually false. It now derives examples from `String(array)` plus its numeric parse, i.e. the same ToPrimitive path `==` itself takes, so arbitrary arrays (`[5]`, `[[['7']]]`, `[1, 2]`…) get correct examples instead of only the hardcoded 0/1/empty cases.

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)