### PR TITLE
bugfix: coerce objects the way == actually does

### DIFF
--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -214,32 +214,37 @@ function handleArray(array) {
 }
 
 /**
+ * An object operand of `==` is only ever compared through its ToPrimitive coercion, so its examples are the primitive values loosely equal to that coercion; other objects never qualify since they are compared by reference.
  * @param {Object} object
  * @return {Example}
  */
 function handleObject(object) {
-	const toPrimitive = object[Symbol.toPrimitive];
-	if (typeof toPrimitive === 'function') {
-		try {
-			const primitive = toPrimitive();
-			return giveExamples(primitive);
-		} catch (error) {
-			console.trace('Failed to invoke Symbol.toPrimitive.', error);
+	let primitive;
 
-			if (object instanceof Date) {
-				return {
-					isInfinite: true,
-					examples: generateObjectWrappedArrayUpToNTimes(object, 10)
-				};
-			}
+	try {
+		primitive = coerceToPrimitive(object);
+	} catch (error) {
+		console.trace('Failed to coerce the object into a primitive value.', error);
 
-			// anything else?
-		}
+		return {
+			isInfinite: false,
+			examples: []
+		};
 	}
+
+	// `==` compares null and undefined to objects without coercing, so an object whose primitive is null or undefined equals nothing
+	if (primitive === undefined || primitive === null) {
+		return {
+			isInfinite: false,
+			examples: []
+		};
+	}
+
+	const { examples } = giveExamples(primitive);
 
 	return {
 		isInfinite: false,
-		examples: []
+		examples: [...new Set(examples.filter(isPrimitive))]
 	};
 }
 
@@ -276,6 +281,44 @@ function tryParsingToNumber(string) {
 	}
 
 	return parsed;
+}
+
+/**
+ * Emulates how `==` coerces its object operand: Symbol.toPrimitive with the 'default' hint when present, otherwise valueOf then toString.
+ * {@link https://262.ecma-international.org/#sec-toprimitive}
+ * @param {Object} object
+ * @return {undefined|null|boolean|number|bigint|string|symbol}
+ */
+function coerceToPrimitive(object) {
+	const toPrimitive = object[Symbol.toPrimitive];
+	if (typeof toPrimitive === 'function') {
+		const primitive = toPrimitive.call(object, 'default');
+		if (isPrimitive(primitive)) {
+			return primitive;
+		}
+
+		throw TypeError('Symbol.toPrimitive returned a non-primitive value.');
+	}
+
+	for (const name of ['valueOf', 'toString']) {
+		const method = object[name];
+		if (typeof method === 'function') {
+			const candidate = method.call(object);
+			if (isPrimitive(candidate)) {
+				return candidate;
+			}
+		}
+	}
+
+	throw TypeError('Cannot convert the object to a primitive value.');
+}
+
+/**
+ * @param any
+ * @return {boolean}
+ */
+function isPrimitive(any) {
+	return Object(any) !== any;
 }
 
 /**

--- a/tests/example-giver.test.js
+++ b/tests/example-giver.test.js
@@ -124,3 +124,94 @@ test(
 		}
 	}
 );
+
+test(
+	'a plain object is equated with "[object Object]"',
+	() => {
+		const { examples } = giveExamples({});
+
+		assert.ok(examples.includes('[object Object]'));
+	}
+);
+
+test(
+	'an object with valueOf is equated with the number and its string form',
+	() => {
+		const { examples } = giveExamples({ valueOf: () => 5 });
+
+		assert.ok(examples.includes(5));
+		assert.ok(examples.includes('5'));
+		assert.ok(!examples.includes('[object Object]'));
+	}
+);
+
+test(
+	'Symbol.toPrimitive is invoked on the object with the "default" hint',
+	() => {
+		let receiver;
+		let hint;
+		const object = {
+			[Symbol.toPrimitive](...args) {
+				receiver = this;
+				[hint] = args;
+
+				return '2';
+			}
+		};
+
+		const { examples } = giveExamples(object);
+
+		assert.equal(receiver, object);
+		assert.equal(hint, 'default');
+		assert.ok(examples.includes('2'));
+		assert.ok(examples.includes(2));
+	}
+);
+
+test(
+	'a Date is equated with its string form without needing a special case',
+	() => {
+		const date = new Date();
+
+		const { examples } = giveExamples(date);
+
+		assert.deepEqual(examples, [String(date)]);
+	}
+);
+
+test(
+	'object examples are finite and never contain other objects',
+	() => {
+		const objects = [{}, { valueOf: () => 1 }, { [Symbol.toPrimitive]: () => '1' }, new Date()];
+
+		for (const object of objects) {
+			const { isInfinite, examples } = giveExamples(object);
+
+			assert.equal(isInfinite, false);
+			assert.ok(examples.every((example) => Object(example) !== example));
+		}
+	}
+);
+
+test(
+	'an object with no way to coerce is equated with nothing',
+	() => {
+		const { examples } = giveExamples(Object.create(null));
+
+		assert.deepEqual(examples, []);
+	}
+);
+
+test(
+	'every object example is actually loosely equal to the object',
+	() => {
+		const objects = [{}, { valueOf: () => 5 }, { toString: () => '1' }, { [Symbol.toPrimitive]: () => 0 }, new Date()];
+
+		for (const object of objects) {
+			const { examples } = giveExamples(object);
+
+			assert.ok(examples.length > 0);
+			assert.ok(examples.every((example) => example == object));
+		}
+	}
+);


### PR DESCRIPTION
`handleObject` called `Symbol.toPrimitive` unbound and without a hint, so it threw for any object that actually implements it (e.g. `Date`) and the fallback misfired. It now runs the real ToPrimitive protocol: `Symbol.toPrimitive` invoked on the object with the `'default'` hint, falling back to `valueOf` then `toString`, mirroring what `==` does.

Consequences:
- A `Date` no longer needs its special case — it reports its string form like any other object (`==` uses the `'default'` hint, which `Date` maps to string).
- Object examples now contain primitives only, deduplicated; an object is never `==` to another object except by identity, so listing wrapper objects was misleading.
- Objects with no usable coercion (e.g. `Object.create(null)` with a poisoned `toString`) are correctly equated with nothing.

Fixes #29
Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)