### PR TITLE
bugfix: carry the Object() wrap depth with each example

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,33 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+	js.configs.recommended,
+	{
+		files: ['index.js', 'scripts/**/*.js'],
+		languageOptions: {
+			sourceType: 'script',
+			globals: globals.browser
+		}
+	},
+	{
+		files: ['index.js'],
+		languageOptions: {
+			globals: {
+				giveExamples: 'readonly',
+				format: 'readonly'
+			}
+		}
+	},
+	{
+		files: ['tests/**/*.js'],
+		languageOptions: {
+			sourceType: 'commonjs',
+			globals: {
+				...globals.node,
+				giveExamples: 'readonly',
+				format: 'readonly'
+			}
+		}
+	}
+];

--- a/index.js
+++ b/index.js
@@ -73,15 +73,12 @@ function run() {
 		const { isInfinite, examples } = giveExamples(x);
 
 		if (examples.length > 0) {
+			result = examples
+				.map(({ value, depth }) => `x == ${format(value, depth)}`)
+				.join('\n');
+
 			if (isInfinite) {
-				result = examples
-					.map((example, index) => `x == ${format(example, index)}`)
-					.join('\n')
-					.concat('\n…');
-			} else {
-				result = examples
-					.map(example => `x == ${format(example)}`)
-					.join('\n');
+				result = result.concat('\n…');
 			}
 
 			output.classList.add('success');

--- a/scripts/example-giver.js
+++ b/scripts/example-giver.js
@@ -1,8 +1,15 @@
 /**
+ * @typedef ExampleEntry
+ * @type {Object}
+ * @property {*} value
+ * @property {number} depth how many Object(…) layers to render around the value's own representation
+ */
+
+/**
  * @typedef Example
  * @type {Object}
  * @property {boolean} isInfinite
- * @property {Array} examples
+ * @property {Array<ExampleEntry>} examples
  */
 
 /**
@@ -22,29 +29,31 @@ function giveExamples(x) {
 		case 'undefined':
 			return {
 				isInfinite: false,
-				examples: [undefined, null]
+				examples: toPlainExamples([undefined, null])
 			};
 		case 'number':
 		case 'bigint':
 			return {
 				isInfinite: false,
-				examples: [x, String(x)]
+				examples: toPlainExamples([x, String(x)])
 			};
 		case 'boolean':
 			throw Error(`${x} is another Boolean value other than true or false!?`);
 		case 'string': {
 			const parsed = tryParsingToNumber(x);
+			const plainValues = [x];
+
 			if (parsed !== undefined) {
-				return {
-					isInfinite: true,
-					examples: [x, parsed].concat(generateWrappedArrayUpToNTimes(x, 10, String))
-				};
-			} else {
-				return {
-					isInfinite: true,
-					examples: [x].concat(generateWrappedArrayUpToNTimes(x, 10, String))
-				};
+				plainValues.push(parsed);
 			}
+
+			const examples = toPlainExamples(plainValues)
+				.concat(generateWrapperExamples(x, 0, 9));
+
+			return {
+				isInfinite: true,
+				examples
+			};
 		}
 		case 'object':
 			if (Array.isArray(x)) {
@@ -80,14 +89,14 @@ function handleSpecialCases(x) {
 	if (x === null) {
 		return {
 			isInfinite: false,
-			examples: [undefined, null]
+			examples: toPlainExamples([undefined, null])
 		};
 	}
 
 	if (x === false || x === 0) {
 		return {
 			isInfinite: true,
-			examples: [
+			examples: toPlainExamples([
 				false,
 				0,
 				'0',
@@ -101,34 +110,36 @@ function handleSpecialCases(x) {
 				[[[]]],
 				[[[0]]],
 				[[['0']]]
-			]
+			])
 		};
 	}
 
 	if (x === '0') {
-		// TODO: add objects using String constructor
+		const examples = toPlainExamples([
+			false,
+			0,
+			'0',
+			[0],
+			['0'],
+			[[0]],
+			[['0']],
+			[[[0]]],
+			[[['0']]],
+			[[[[0]]]],
+			[[[['0']]]]
+		])
+			.concat(generateWrapperExamples(x, 0, 2));
+
 		return {
 			isInfinite: true,
-			examples: [
-				false,
-				0,
-				'0',
-				[0],
-				['0'],
-				[[0]],
-				[['0']],
-				[[[0]]],
-				[[['0']]],
-				[[[[0]]]],
-				[[[['0']]]]
-			]
+			examples
 		};
 	}
 
 	if (x === true || x === 1) {
 		return {
 			isInfinite: true,
-			examples: [
+			examples: toPlainExamples([
 				true,
 				1,
 				'1',
@@ -140,47 +151,51 @@ function handleSpecialCases(x) {
 				[[['1']]],
 				[[[[1]]]],
 				[[[['1']]]]
-			]
+			])
 		};
 	}
 
 	if (x === '1') {
-		// TODO: add objects using String constructor
+		const examples = toPlainExamples([
+			true,
+			1,
+			'1',
+			[1],
+			['1'],
+			[[1]],
+			[['1']],
+			[[[1]]],
+			[[['1']]],
+			[[[[1]]]],
+			[[[['1']]]]
+		])
+			.concat(generateWrapperExamples(x, 0, 2));
+
 		return {
 			isInfinite: true,
-			examples: [
-				true,
-				1,
-				'1',
-				[1],
-				['1'],
-				[[1]],
-				[['1']],
-				[[[1]]],
-				[[['1']]],
-				[[[[1]]]],
-				[[[['1']]]]
-			]
+			examples
 		};
 	}
 
 	if (x === '') {
-		// TODO: add objects using String constructor
+		const examples = toPlainExamples([
+			false,
+			0,
+			'',
+			[],
+			[[]],
+			[[[]]],
+			[[[[]]]],
+			[[[[[]]]]],
+			[[[[[[]]]]]],
+			[[[[[[[]]]]]]],
+			[[[[[[[[]]]]]]]]
+		])
+			.concat(generateWrapperExamples(x, 0, 2));
+
 		return {
 			isInfinite: true,
-			examples: [
-				false,
-				0,
-				'',
-				[],
-				[[]],
-				[[[]]],
-				[[[[]]]],
-				[[[[[]]]]],
-				[[[[[[]]]]]],
-				[[[[[[[]]]]]]],
-				[[[[[[[[]]]]]]]]
-			]
+			examples
 		};
 	}
 }
@@ -193,23 +208,23 @@ function handleSpecialCases(x) {
 function handleArray(array) {
 	const string = String(array);
 	const parsed = tryParsingToNumber(string);
-	const examples = [];
+	const values = [];
 
 	if (parsed === 0) {
-		examples.push(false);
+		values.push(false);
 	} else if (parsed === 1) {
-		examples.push(true);
+		values.push(true);
 	}
 
 	if (parsed !== undefined) {
-		examples.push(parsed);
+		values.push(parsed);
 	}
 
-	examples.push(string);
+	values.push(string);
 
 	return {
 		isInfinite: false,
-		examples
+		examples: toPlainExamples(values)
 	};
 }
 
@@ -241,10 +256,12 @@ function handleObject(object) {
 	}
 
 	const { examples } = giveExamples(primitive);
+	const values = examples.map(({ value }) => value);
+	const primitiveValues = [...new Set(values)].filter(isPrimitive);
 
 	return {
 		isInfinite: false,
-		examples: [...new Set(examples.filter(isPrimitive))]
+		examples: toPlainExamples(primitiveValues)
 	};
 }
 
@@ -253,9 +270,12 @@ function handleObject(object) {
  * @return {Example}
  */
 function handleSymbol(symbol) {
+	const examples = toPlainExamples([symbol])
+		.concat(generateWrapperExamples(symbol, 1, 10));
+
 	return {
 		isInfinite: true,
-		examples: generateObjectWrappedArrayUpToNTimes(symbol, 10)
+		examples
 	};
 }
 
@@ -266,7 +286,7 @@ function handleSymbol(symbol) {
 function handleFunction(fn) {
 	return {
 		isInfinite: false,
-		examples: [fn]
+		examples: toPlainExamples([fn])
 	};
 }
 
@@ -322,55 +342,27 @@ function isPrimitive(any) {
 }
 
 /**
- * @param any
- * @param {number} n
- * @param constructor
- * @return {Array}
+ * @param {Array} values
+ * @return {Array<ExampleEntry>}
  */
-function generateWrappedArrayUpToNTimes(any, n, constructor) {
-	const array = [];
-
-	for (let i = 0; i <= n; i++) {
-		array.push(wrapWithConstructorNTimes(any, i, constructor));
-	}
-
-	return array;
+function toPlainExamples(values) {
+	return values.map((value) => ({ value, depth: 0 }));
 }
 
 /**
+ * A single Object() call produces the wrapper for every depth: wrapping the wrapper again would return the very same object, so only the rendered depth grows.
  * @param any
- * @param {number} n
- * @param {Function} constructor
- * @return {*|Object}
+ * @param {number} from
+ * @param {number} to
+ * @return {Array<ExampleEntry>}
  */
-function wrapWithConstructorNTimes(any, n, constructor) {
-	if (n === 0) {
-		return any;
+function generateWrapperExamples(any, from, to) {
+	const wrapper = Object(any);
+	const examples = [];
+
+	for (let depth = from; depth <= to; depth++) {
+		examples.push({ value: wrapper, depth });
 	}
 
-	const wrapped = constructor(any);
-
-	if (n === 1) {
-		return wrapped;
-	}
-
-	return wrapWithObjectNTimes(wrapped, n - 1);
-}
-
-/**
- * @param any
- * @param {number} n
- * @return {Array}
- */
-function generateObjectWrappedArrayUpToNTimes(any, n) {
-	return generateWrappedArrayUpToNTimes(any, n, Object);
-}
-
-/**
- * @param any
- * @param {number} n
- * @return {*|Object}
- */
-function wrapWithObjectNTimes(any, n) {
-	return wrapWithConstructorNTimes(any, n, Object);
+	return examples;
 }

--- a/scripts/formatter.js
+++ b/scripts/formatter.js
@@ -1,3 +1,5 @@
+/* exported format */
+
 /**
  * @typedef Input
  * @type {undefined|null|boolean|number|bigint|symbol|string|Date|Object}

--- a/tests/example-giver.test.js
+++ b/tests/example-giver.test.js
@@ -3,111 +3,118 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-// example-giver.js is a plain browser script without exports; direct eval brings its declarations into scope
+// example-giver.js and formatter.js are plain browser scripts without exports; direct eval brings their declarations into scope
 eval(fs.readFileSync(path.join(__dirname, '../scripts/example-giver.js'), 'utf-8'));
+eval(fs.readFileSync(path.join(__dirname, '../scripts/formatter.js'), 'utf-8'));
+
+/**
+ * @param {Example} example
+ * @return {Array}
+ */
+const valuesOf = ({ examples }) => examples.map(({ value }) => value);
 
 test(
 	'"1.5" is equated with 1.5, not the parseInt result 1',
 	() => {
-		const { examples } = giveExamples('1.5');
+		const values = valuesOf(giveExamples('1.5'));
 
-		assert.ok(examples.includes(1.5));
-		assert.ok(!examples.includes(1));
+		assert.ok(values.includes(1.5));
+		assert.ok(!values.includes(1));
 	}
 );
 
 test(
 	'"1e3" is equated with 1000, not the parseInt result 1',
 	() => {
-		const { examples } = giveExamples('1e3');
+		const values = valuesOf(giveExamples('1e3'));
 
-		assert.ok(examples.includes(1000));
-		assert.ok(!examples.includes(1));
+		assert.ok(values.includes(1000));
+		assert.ok(!values.includes(1));
 	}
 );
 
 test(
 	'"1abc" is not equated with any number despite parseFloat accepting it',
 	() => {
-		const { examples } = giveExamples('1abc');
+		const values = valuesOf(giveExamples('1abc'));
 
-		assert.ok(examples.every((example) => typeof example !== 'number'));
+		assert.ok(values.every((value) => typeof value !== 'number'));
 	}
 );
 
 test(
 	'"00" is equated with 0 even though 0 is falsy',
 	() => {
-		const { examples } = giveExamples('00');
+		const values = valuesOf(giveExamples('00'));
 
-		assert.ok(examples.includes(0));
+		assert.ok(values.includes(0));
 	}
 );
 
 test(
 	'["1abc"] is not claimed to equal 1',
 	() => {
-		const { examples } = giveExamples(['1abc']);
+		const values = valuesOf(giveExamples(['1abc']));
 
-		assert.ok(examples.every((example) => typeof example !== 'number'));
+		assert.ok(values.every((value) => typeof value !== 'number'));
 	}
 );
 
 test(
 	'["1abc"] is equated with its string form',
 	() => {
-		const { examples } = giveExamples(['1abc']);
+		const values = valuesOf(giveExamples(['1abc']));
 
-		assert.ok(examples.includes('1abc'));
+		assert.ok(values.includes('1abc'));
 	}
 );
 
 test(
 	'[2] is equated with 2 and "2"',
 	() => {
-		const { examples } = giveExamples([2]);
+		const values = valuesOf(giveExamples([2]));
 
-		assert.ok(examples.includes(2));
-		assert.ok(examples.includes('2'));
+		assert.ok(values.includes(2));
+		assert.ok(values.includes('2'));
 	}
 );
 
 test(
 	'[1,2] is equated with "1,2"',
 	() => {
-		const { examples } = giveExamples([1, 2]);
+		const values = valuesOf(giveExamples([1, 2]));
 
-		assert.ok(examples.includes('1,2'));
+		assert.ok(values.includes('1,2'));
 	}
 );
 
 test(
 	'[" "] is equated with 0 but not with "0"',
 	() => {
-		const { examples } = giveExamples([' ']);
+		const values = valuesOf(giveExamples([' ']));
 
-		assert.ok(examples.includes(0));
-		assert.ok(!examples.includes('0'));
+		assert.ok(values.includes(0));
+		assert.ok(!values.includes('0'));
 	}
 );
 
 test(
 	'[null] is equated with "" but not with "0"',
 	() => {
-		const { examples } = giveExamples([null]);
+		const values = valuesOf(giveExamples([null]));
 
-		assert.ok(examples.includes(''));
-		assert.ok(!examples.includes('0'));
+		assert.ok(values.includes(''));
+		assert.ok(!values.includes('0'));
 	}
 );
 
 test(
 	'nested falsy/truthy singleton arrays keep their equalities',
 	() => {
-		assert.deepEqual(giveExamples([]).examples, [false, 0, '']);
-		assert.deepEqual(giveExamples([0]).examples, [false, 0, '0']);
-		assert.deepEqual(giveExamples([1]).examples, [true, 1, '1']);
-		assert.deepEqual(giveExamples([['0']]).examples, [false, 0, '0']);
+		assert.deepEqual(valuesOf(giveExamples([])), [false, 0, '']);
+		assert.deepEqual(valuesOf(giveExamples([0])), [false, 0, '0']);
+		assert.deepEqual(valuesOf(giveExamples([1])), [true, 1, '1']);
+		assert.deepEqual(valuesOf(giveExamples([['0']])), [false, 0, '0']);
 	}
 );
 
@@ -117,10 +124,10 @@ test(
 		const arrays = [[], [0], [1], [2], [1, 2], ['1abc'], [' '], [null], [[42]]];
 
 		for (const array of arrays) {
-			const { examples } = giveExamples(array);
+			const values = valuesOf(giveExamples(array));
 
-			assert.ok(examples.length > 0);
-			assert.ok(examples.every((example) => example == array));
+			assert.ok(values.length > 0);
+			assert.ok(values.every((value) => value == array));
 		}
 	}
 );
@@ -128,20 +135,20 @@ test(
 test(
 	'a plain object is equated with "[object Object]"',
 	() => {
-		const { examples } = giveExamples({});
+		const values = valuesOf(giveExamples({}));
 
-		assert.ok(examples.includes('[object Object]'));
+		assert.ok(values.includes('[object Object]'));
 	}
 );
 
 test(
 	'an object with valueOf is equated with the number and its string form',
 	() => {
-		const { examples } = giveExamples({ valueOf: () => 5 });
+		const values = valuesOf(giveExamples({ valueOf: () => 5 }));
 
-		assert.ok(examples.includes(5));
-		assert.ok(examples.includes('5'));
-		assert.ok(!examples.includes('[object Object]'));
+		assert.ok(values.includes(5));
+		assert.ok(values.includes('5'));
+		assert.ok(!values.includes('[object Object]'));
 	}
 );
 
@@ -159,12 +166,12 @@ test(
 			}
 		};
 
-		const { examples } = giveExamples(object);
+		const values = valuesOf(giveExamples(object));
 
 		assert.equal(receiver, object);
 		assert.equal(hint, 'default');
-		assert.ok(examples.includes('2'));
-		assert.ok(examples.includes(2));
+		assert.ok(values.includes('2'));
+		assert.ok(values.includes(2));
 	}
 );
 
@@ -173,9 +180,7 @@ test(
 	() => {
 		const date = new Date();
 
-		const { examples } = giveExamples(date);
-
-		assert.deepEqual(examples, [String(date)]);
+		assert.deepEqual(valuesOf(giveExamples(date)), [String(date)]);
 	}
 );
 
@@ -188,7 +193,7 @@ test(
 			const { isInfinite, examples } = giveExamples(object);
 
 			assert.equal(isInfinite, false);
-			assert.ok(examples.every((example) => Object(example) !== example));
+			assert.ok(examples.every(({ value }) => Object(value) !== value));
 		}
 	}
 );
@@ -208,10 +213,74 @@ test(
 		const objects = [{}, { valueOf: () => 5 }, { toString: () => '1' }, { [Symbol.toPrimitive]: () => 0 }, new Date()];
 
 		for (const object of objects) {
-			const { examples } = giveExamples(object);
+			const values = valuesOf(giveExamples(object));
 
-			assert.ok(examples.length > 0);
-			assert.ok(examples.every((example) => example == object));
+			assert.ok(values.length > 0);
+			assert.ok(values.every((value) => value == object));
+		}
+	}
+);
+
+test(
+	'string examples carry real String wrapper objects, not re-derived primitives',
+	() => {
+		const { examples } = giveExamples('abc');
+		const wrappers = examples.filter(({ value }) => typeof value === 'object');
+
+		assert.ok(wrappers.length > 0);
+		assert.ok(wrappers.every(({ value }) => value instanceof String));
+	}
+);
+
+test(
+	'wrapped string examples carry their own render depth without shifting',
+	() => {
+		const { examples } = giveExamples('5');
+		const wrapped = examples.filter(({ value }) => typeof value === 'object');
+
+		assert.deepEqual(wrapped.map(({ depth }) => depth), [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+	}
+);
+
+test(
+	'symbol examples keep the raw symbol first and wrappers at increasing depths',
+	() => {
+		const symbol = Symbol('example');
+		const { examples } = giveExamples(symbol);
+
+		assert.equal(examples[0].value, symbol);
+		assert.equal(examples[0].depth, 0);
+		assert.ok(examples.slice(1).every(({ value }) => value instanceof Symbol));
+		assert.deepEqual(examples.slice(1).map(({ depth }) => depth), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+	}
+);
+
+test(
+	'"0", "1" and "" are equated with their String wrapper objects',
+	() => {
+		for (const string of ['0', '1', '']) {
+			const { examples } = giveExamples(string);
+			const wrappers = examples.filter(({ value }) => value instanceof String);
+
+			assert.ok(wrappers.length > 0);
+			assert.ok(wrappers.every(({ value }) => value == string));
+		}
+	}
+);
+
+test(
+	'every rendered example evaluates to a value loosely equal to x',
+	() => {
+		const inputs = [undefined, null, true, false, 0, 1, 42, 42n, '', '0', '1', '5', 'abc', [], [0], [2], [1, 2], {}, new Date()];
+
+		for (const x of inputs) {
+			const { examples } = giveExamples(x);
+
+			for (const { value, depth } of examples) {
+				const rendered = format(value, depth);
+
+				assert.ok(eval(rendered) == x, `expected ${rendered} == ${format(x)}`);
+			}
 		}
 	}
 );


### PR DESCRIPTION
Rendered examples for strings and symbols shifted their wrapper depth by one: the render used the example's array index as the wrap count, but the raw value occupies index 0, so `new String("5")` displayed as `Object(new String("5"))` and so on. Each example now carries its own `{ value, depth }` entry and `run()` renders the carried depth, so nothing shifts and duplicates disappear.

String examples are also built from real `String`/`Object` wrapper objects instead of re-derived primitives, and the `'0'`, `'1'` and `''` special cases gain their String-wrapper examples — resolving the three `TODO: add objects using String constructor` comments.

Fixes #31
Fixes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)